### PR TITLE
Update depencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  http: ^0.12.0
-  path_provider: ^0.4.1
-  webview_flutter: ^0.2.0
+  http: ^0.12.0+1
+  path_provider: ^0.5.0+1
+  webview_flutter: ^0.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I've updated the dependencies. 
For this reason, anyone who wants to use this package must migrate to AndroidX, as webview_flutter and path_provider have also been migrated.
I tested it and i had no erros